### PR TITLE
Missing / strange translations

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.2 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Updated translations for teaser portlet.
+  [Julian Infanger]
 
 
 1.1 (2013-05-24)

--- a/ftw/subsite/locales/de/LC_MESSAGES/ftw.subsite.po
+++ b/ftw/subsite/locales/de/LC_MESSAGES/ftw.subsite.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2013-02-12 10:34+0000\n"
+"POT-Creation-Date: 2013-05-30 06:22+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,27 +16,27 @@ msgstr ""
 msgid "Add Teaser Portlet"
 msgstr "Teaserportlet hinzufügen"
 
-#: ./ftw/subsite/browser/subsiteview.pt:26
+#: ./ftw/subsite/browser/subsiteview.pt:20
 msgid "Choose your Section"
 msgstr "Wählen Sie ihre Sektion"
+
+#: ./ftw/subsite/portlets/teaserportlet.py:27
+msgid "Description"
+msgstr "Beschreibung"
 
 #: ./ftw/subsite/portlets/teaserportlet.py:148
 msgid "Edit Teaser Portlet"
 msgstr "Teaserportlet bearbeiten"
 
-#: ./ftw/subsite/portlets/teaserportlet.py:24
-msgid "Enter a Title"
-msgstr ""
-
-#: ./ftw/subsite/portlets/teaserportlet.py:28
-msgid "Enter a description"
-msgstr ""
-
 #: ./ftw/subsite/portlets/teaserportlet.py:32
 msgid "Find an internal target  for this image to link to"
 msgstr "Geben Sie ein Ziel für dieses Bild an."
 
-#: ./ftw/subsite/browser/subsiteview.pt:29
+#: ./ftw/subsite/portlets/teaserportlet.py:37
+msgid "Image"
+msgstr "Bild"
+
+#: ./ftw/subsite/browser/subsiteview.pt:23
 msgid "Information"
 msgstr "Information"
 
@@ -44,6 +44,7 @@ msgstr "Information"
 msgid "Internal Target"
 msgstr "Internes Ziel"
 
+#: ./ftw/subsite/browser/manage-subsiteview.pt:16
 #: ./ftw/subsite/profiles/default/actions.xml
 msgid "Manage Subsite Portlets"
 msgstr "Subsiteportlets bearbeiten"
@@ -69,13 +70,9 @@ msgstr "Subsite"
 msgid "Subsite - behave like a ploneroot"
 msgstr ""
 
-#: ./ftw/subsite/portlets/teaserportlet.py:27
-msgid "Teaserdescription"
-msgstr "Teaserbeschreibung"
-
 #: ./ftw/subsite/portlets/teaserportlet.py:23
-msgid "Teasertitle"
-msgstr "Teasertitel"
+msgid "Title"
+msgstr "Titel"
 
 #. Default: "Cancel"
 #: ./ftw/subsite/browser/contact.py:56
@@ -83,7 +80,7 @@ msgid "button_cancel"
 msgstr "Abbrechen"
 
 #. Default: "Your e-mailaddress is not valid"
-#: ./ftw/subsite/browser/contact.py:141
+#: ./ftw/subsite/browser/contact.py:142
 msgid "error_invalid_addresses"
 msgstr "Die eingegebene E-Mailaddresse ist nicht korrekt"
 
@@ -96,25 +93,25 @@ msgstr "Text"
 msgid "help_Sender"
 msgstr ""
 
-#: ./ftw/subsite/content/subsite.py:37
+#: ./ftw/subsite/content/subsite.py:36
 msgid "help_additional_css"
 msgstr ""
 
 #. Default: "The Subsite and it's content will be delivered in the choosen language"
-#: ./ftw/subsite/content/subsite.py:62
+#: ./ftw/subsite/content/subsite.py:63
 msgid "help_forcelanguage"
 msgstr "Die aktuelle Subsite und deren Inhalt werden in der angegebenen Sprache angezeigt. Alle anderen Einstellungen werden ignoriert."
 
-#: ./ftw/subsite/content/subsite.py:70
+#: ./ftw/subsite/content/subsite.py:71
 msgid "help_fromname"
 msgstr ""
 
 #. Default: "The language switch will only be displayed, if the chosen Subsite(s)has a value in the forcelangage field"
-#: ./ftw/subsite/content/subsite.py:49
+#: ./ftw/subsite/content/subsite.py:50
 msgid "help_language_references"
 msgstr "Die Sprachsteuerung wird nur angezeigt, falls die referenzierten Subsites ein Sprache definiert haben."
 
-#: ./ftw/subsite/content/subsite.py:25
+#: ./ftw/subsite/content/subsite.py:24
 msgid "help_logo"
 msgstr ""
 
@@ -138,12 +135,13 @@ msgstr ""
 msgid "info_email_sent"
 msgstr "Die Email wurde versendet"
 
+#. Default: "inherit language"
 #: ./ftw/subsite/vocabularies.py:19
 msgid "inherit_language"
 msgstr "Standart Sprache übernehmen"
 
 #. Default: "Additional CSS"
-#: ./ftw/subsite/content/subsite.py:35
+#: ./ftw/subsite/content/subsite.py:34
 msgid "label_additional_css"
 msgstr "zusätzliches CSS"
 
@@ -153,27 +151,27 @@ msgid "label_cancel"
 msgstr "Abbrechen"
 
 #. Default: "Subsite language"
-#: ./ftw/subsite/content/subsite.py:61
+#: ./ftw/subsite/content/subsite.py:62
 msgid "label_forcelanguage"
 msgstr "Sprache für die Subsite festlegen"
 
 #. Default: "Email Senderaddress"
-#: ./ftw/subsite/content/subsite.py:75
+#: ./ftw/subsite/content/subsite.py:76
 msgid "label_fromemail"
 msgstr "Absender E-Mail"
 
 #. Default: "Email Sendername"
-#: ./ftw/subsite/content/subsite.py:69
+#: ./ftw/subsite/content/subsite.py:70
 msgid "label_fromname"
 msgstr "Absender Name"
 
 #. Default: "Languages"
-#: ./ftw/subsite/content/subsite.py:47
+#: ./ftw/subsite/content/subsite.py:48
 msgid "label_language_references"
 msgstr "Auf andere Sprachen verlinken"
 
 #. Default: "Logo"
-#: ./ftw/subsite/content/subsite.py:23
+#: ./ftw/subsite/content/subsite.py:22
 msgid "label_logo"
 msgstr "Logo"
 

--- a/ftw/subsite/locales/ftw.subsite.pot
+++ b/ftw/subsite/locales/ftw.subsite.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2013-02-12 10:34+0000\n"
+"POT-Creation-Date: 2013-05-30 06:22+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,27 +21,27 @@ msgstr ""
 msgid "Add Teaser Portlet"
 msgstr ""
 
-#: ./ftw/subsite/browser/subsiteview.pt:26
+#: ./ftw/subsite/browser/subsiteview.pt:20
 msgid "Choose your Section"
+msgstr ""
+
+#: ./ftw/subsite/portlets/teaserportlet.py:27
+msgid "Description"
 msgstr ""
 
 #: ./ftw/subsite/portlets/teaserportlet.py:148
 msgid "Edit Teaser Portlet"
 msgstr ""
 
-#: ./ftw/subsite/portlets/teaserportlet.py:24
-msgid "Enter a Title"
-msgstr ""
-
-#: ./ftw/subsite/portlets/teaserportlet.py:28
-msgid "Enter a description"
-msgstr ""
-
 #: ./ftw/subsite/portlets/teaserportlet.py:32
 msgid "Find an internal target  for this image to link to"
 msgstr ""
 
-#: ./ftw/subsite/browser/subsiteview.pt:29
+#: ./ftw/subsite/portlets/teaserportlet.py:37
+msgid "Image"
+msgstr ""
+
+#: ./ftw/subsite/browser/subsiteview.pt:23
 msgid "Information"
 msgstr ""
 
@@ -49,6 +49,7 @@ msgstr ""
 msgid "Internal Target"
 msgstr ""
 
+#: ./ftw/subsite/browser/manage-subsiteview.pt:16
 #: ./ftw/subsite/profiles/default/actions.xml
 msgid "Manage Subsite Portlets"
 msgstr ""
@@ -74,12 +75,8 @@ msgstr ""
 msgid "Subsite - behave like a ploneroot"
 msgstr ""
 
-#: ./ftw/subsite/portlets/teaserportlet.py:27
-msgid "Teaserdescription"
-msgstr ""
-
 #: ./ftw/subsite/portlets/teaserportlet.py:23
-msgid "Teasertitle"
+msgid "Title"
 msgstr ""
 
 #. Default: "Cancel"
@@ -88,7 +85,7 @@ msgid "button_cancel"
 msgstr ""
 
 #. Default: "Your e-mailaddress is not valid"
-#: ./ftw/subsite/browser/contact.py:141
+#: ./ftw/subsite/browser/contact.py:142
 msgid "error_invalid_addresses"
 msgstr ""
 
@@ -101,25 +98,25 @@ msgstr ""
 msgid "help_Sender"
 msgstr ""
 
-#: ./ftw/subsite/content/subsite.py:37
+#: ./ftw/subsite/content/subsite.py:36
 msgid "help_additional_css"
 msgstr ""
 
 #. Default: "The Subsite and it's content will be delivered in the choosen language"
-#: ./ftw/subsite/content/subsite.py:62
+#: ./ftw/subsite/content/subsite.py:63
 msgid "help_forcelanguage"
 msgstr ""
 
-#: ./ftw/subsite/content/subsite.py:70
+#: ./ftw/subsite/content/subsite.py:71
 msgid "help_fromname"
 msgstr ""
 
 #. Default: "The language switch will only be displayed, if the chosen Subsite(s)has a value in the forcelangage field"
-#: ./ftw/subsite/content/subsite.py:49
+#: ./ftw/subsite/content/subsite.py:50
 msgid "help_language_references"
 msgstr ""
 
-#: ./ftw/subsite/content/subsite.py:25
+#: ./ftw/subsite/content/subsite.py:24
 msgid "help_logo"
 msgstr ""
 
@@ -143,12 +140,13 @@ msgstr ""
 msgid "info_email_sent"
 msgstr ""
 
+#. Default: "inherit language"
 #: ./ftw/subsite/vocabularies.py:19
 msgid "inherit_language"
 msgstr ""
 
 #. Default: "Additional CSS"
-#: ./ftw/subsite/content/subsite.py:35
+#: ./ftw/subsite/content/subsite.py:34
 msgid "label_additional_css"
 msgstr ""
 
@@ -158,27 +156,27 @@ msgid "label_cancel"
 msgstr ""
 
 #. Default: "Subsite language"
-#: ./ftw/subsite/content/subsite.py:61
+#: ./ftw/subsite/content/subsite.py:62
 msgid "label_forcelanguage"
 msgstr ""
 
 #. Default: "Email Senderaddress"
-#: ./ftw/subsite/content/subsite.py:75
+#: ./ftw/subsite/content/subsite.py:76
 msgid "label_fromemail"
 msgstr ""
 
 #. Default: "Email Sendername"
-#: ./ftw/subsite/content/subsite.py:69
+#: ./ftw/subsite/content/subsite.py:70
 msgid "label_fromname"
 msgstr ""
 
 #. Default: "Languages"
-#: ./ftw/subsite/content/subsite.py:47
+#: ./ftw/subsite/content/subsite.py:48
 msgid "label_language_references"
 msgstr ""
 
 #. Default: "Logo"
-#: ./ftw/subsite/content/subsite.py:23
+#: ./ftw/subsite/content/subsite.py:22
 msgid "label_logo"
 msgstr ""
 

--- a/ftw/subsite/portlets/teaserportlet.py
+++ b/ftw/subsite/portlets/teaserportlet.py
@@ -20,12 +20,12 @@ class ITeaserPortlet(IPortletDataProvider):
     """A portlet which can some given Infos
     """
 
-    teasertitle = schema.TextLine(title=_(u'Teasertitle'),
-                                  description=_(u'Enter a Title'),
+    teasertitle = schema.TextLine(title=_(u'Title'),
+                                  description=u'',
                                   required=True)
 
-    teaserdesc = schema.Text(title=_(u'Teaserdescription'),
-                             description=_(u"Enter a description"),
+    teaserdesc = schema.Text(title=_(u'Description'),
+                             description=u'',
                              required=True)
 
     internal_target = schema.Choice(title=_(u"Internal Target"),
@@ -34,8 +34,8 @@ class ITeaserPortlet(IPortletDataProvider):
                                    required=False,
                                    source=UUIDSourceBinder({})
                                     )
-    image = NamedImage(title=u'Image field',
-                        description=u"Add or replace image for the portlet",
+    image = NamedImage(title=_(u'Image'),
+                        description=u'',
                         required=True)
 
 


### PR DESCRIPTION
https://github.com/4teamwork/ftw.subsite/blob/master/ftw/subsite/portlets/teaserportlet.py
- In my opinion there should be "Titel" and "Beschreibung" the translations, like in default content types.
- Help text for title and description can be removed if it doesn't say more than the label.

![Bildschirmfoto 2013-04-22 um 08 44 21](https://f.cloud.github.com/assets/157533/407858/465bf94e-ab18-11e2-93fa-db24977ccc83.png)
