### PR TITLE
Teaser portlet calls referenced target in pagetemplate resulting in horrible performance

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,8 +4,8 @@ Changelog
 1.1.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Fix performance issue while rendering the teaser portlet.
+  [mathias.leimgruber]
 
 1.1.2 (2013-06-04)
 ------------------

--- a/ftw/subsite/portlets/teaserportlet.pt
+++ b/ftw/subsite/portlets/teaserportlet.pt
@@ -1,11 +1,10 @@
-<metal:block use-macro="here/global_defines/macros/defines" />
 <dl class="portlet teaser_portlet" tal:define="teasertitle view/getTeaserTitle;
                  teaserdesc view/getTeaserDesc;
-                 internal_target nocall:view/internal_obj;
+                 internal_url view/internal_url;
                  image view/image_tag
                  ">
     <dt class="portletHeader">
-    	<a tal:omit-tag="not: internal_target" tal:attributes="href python:internal_target and internal_target.absolute_url()">
+    	<a tal:omit-tag="not: internal_url" tal:attributes="href internal_url">
           <img tal:replace="structure image" />
           <span class="teaser_title" tal:replace="structure teasertitle" />
     	</a>

--- a/ftw/subsite/portlets/teaserportlet.py
+++ b/ftw/subsite/portlets/teaserportlet.py
@@ -66,9 +66,13 @@ class Renderer(base.Renderer):
         return self.data.teaserdesc
 
     @property
-    def internal_obj(self):
+    def internal_url(self):
         object_path = self.data.internal_target
-        return uuidToObject(object_path)
+        internal_obj = uuidToObject(object_path)
+        if internal_obj:
+            return internal_obj.absolute_url()
+        else:
+            return ''
 
     @property
     @memoize

--- a/ftw/subsite/tests/test_subsiteportlet.py
+++ b/ftw/subsite/tests/test_subsiteportlet.py
@@ -157,9 +157,9 @@ class TestSubsite(unittest.TestCase):
         renderer = self._get_renderer()
         self.assertEqual("<img src='http://nohost/plone/++contextportlets++ftw.subsite.front1/hans/@@image' alt=''/>", renderer.image_tag)
 
-    def test_renderer_internal_obj(self):
+    def test_renderer_internal_url(self):
         renderer = self._get_renderer()
-        self.assertEqual(self.page, renderer.internal_obj)
+        self.assertEqual(self.page.absolute_url(), renderer.internal_url)
 
     def test_image_view(self):
         self._auth()


### PR DESCRIPTION
internal_target is called on line 9 which results in rendering the target page:

```
<a tal:omit-tag="not: internal_target" tal:attributes="href python:internal_target and internal_target.absolute_url()">
```

further `<metal:block use-macro="here/global_defines/macros/defines" />` is deprecated since Plone 4.0. Please remove it!
