### PR TITLE
Add checkbox for showing Plone Site in language switcher

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 1.1.5 (unreleased)
 ------------------
 
+- Add checkbox for showing Plone Site in language switcher.
+  [jone]
+
 - Added css-class to subsite logo.
   [Julian Infanger]
 

--- a/ftw/subsite/browser/selector.py
+++ b/ftw/subsite/browser/selector.py
@@ -22,7 +22,13 @@ class LanguageSelector(common.ViewletBase):
         return self._nav_root
 
     def available(self):
-        if ISubsite.providedBy(self.navigation_root):
+        if not ISubsite.providedBy(self.navigation_root):
+            return False
+
+        elif self.navigation_root.showLinkToSiteInLanguageChooser():
+            return True
+
+        else:
             return bool(self.navigation_root.getLanguage_references())
 
     def languages(self):
@@ -39,6 +45,15 @@ class LanguageSelector(common.ViewletBase):
                     dict(code=lang,
                          url=subsite.absolute_url(),
                          native=self.getNativeForLanguageCode(ltool, lang)))
+
+        if self.navigation_root.showLinkToSiteInLanguageChooser():
+            portal_url = getToolByName(self.navigation_root, 'portal_url')
+            lang = ltool.getDefaultLanguage()
+
+            languages.append(
+                dict(code=lang,
+                     url=portal_url(),
+                     native=self.getNativeForLanguageCode(ltool, lang)))
 
         return languages
 

--- a/ftw/subsite/content/subsite.py
+++ b/ftw/subsite/content/subsite.py
@@ -56,6 +56,14 @@ schema = atapi.Schema((
                                      'has a value in the forcelangage '
                                      'field')))),
 
+    atapi.BooleanField(
+            name='linkSiteInLanguagechooser',
+            accessor='showLinkToSiteInLanguageChooser',
+            schemata='subsite',
+            default=False,
+            widget=atapi.BooleanWidget(
+                label=_(u'Link Plone Site in language chooser'))),
+
     atapi.StringField(
         name="forcelanguage",
         default="",

--- a/ftw/subsite/locales/de/LC_MESSAGES/ftw.subsite.po
+++ b/ftw/subsite/locales/de/LC_MESSAGES/ftw.subsite.po
@@ -43,6 +43,10 @@ msgstr "Information"
 msgid "Internal Target"
 msgstr "Internes Ziel"
 
+#: ./ftw/subsite/content/subsite.py:65
+msgid "Link Plone Site in language chooser"
+msgstr "Plone Seite in Sprachauswahl anzeigen."
+
 #: ./ftw/subsite/browser/manage-subsiteview.pt:16
 #: ./ftw/subsite/profiles/default/actions.xml
 msgid "Manage Subsite Portlets"
@@ -93,11 +97,11 @@ msgid "help_additional_css"
 msgstr ""
 
 #. Default: "The Subsite and it's content will be delivered in the choosen language"
-#: ./ftw/subsite/content/subsite.py:66
+#: ./ftw/subsite/content/subsite.py:74
 msgid "help_forcelanguage"
 msgstr "Die aktuelle Subsite und deren Inhalt werden in der angegebenen Sprache angezeigt. Alle anderen Einstellungen werden ignoriert."
 
-#: ./ftw/subsite/content/subsite.py:74
+#: ./ftw/subsite/content/subsite.py:82
 msgid "help_fromname"
 msgstr ""
 
@@ -146,17 +150,17 @@ msgid "label_cancel"
 msgstr "Abbrechen"
 
 #. Default: "Subsite language"
-#: ./ftw/subsite/content/subsite.py:65
+#: ./ftw/subsite/content/subsite.py:73
 msgid "label_forcelanguage"
 msgstr "Sprache für die Subsite festlegen"
 
 #. Default: "Email Senderaddress"
-#: ./ftw/subsite/content/subsite.py:79
+#: ./ftw/subsite/content/subsite.py:87
 msgid "label_fromemail"
 msgstr "Absender E-Mail"
 
 #. Default: "Email Sendername"
-#: ./ftw/subsite/content/subsite.py:73
+#: ./ftw/subsite/content/subsite.py:81
 msgid "label_fromname"
 msgstr "Absender Name"
 
@@ -194,4 +198,3 @@ msgstr "Betreff"
 #: ./ftw/subsite/browser/contact.py:24
 msgid "mail_address"
 msgstr "E-Mail"
-

--- a/ftw/subsite/locales/ftw.subsite.pot
+++ b/ftw/subsite/locales/ftw.subsite.pot
@@ -49,6 +49,10 @@ msgstr ""
 msgid "Internal Target"
 msgstr ""
 
+#: ./ftw/subsite/content/subsite.py:65
+msgid "Link Plone Site in language chooser"
+msgstr ""
+
 #: ./ftw/subsite/browser/manage-subsiteview.pt:16
 #: ./ftw/subsite/profiles/default/actions.xml
 msgid "Manage Subsite Portlets"
@@ -99,11 +103,11 @@ msgid "help_additional_css"
 msgstr ""
 
 #. Default: "The Subsite and it's content will be delivered in the choosen language"
-#: ./ftw/subsite/content/subsite.py:66
+#: ./ftw/subsite/content/subsite.py:74
 msgid "help_forcelanguage"
 msgstr ""
 
-#: ./ftw/subsite/content/subsite.py:74
+#: ./ftw/subsite/content/subsite.py:82
 msgid "help_fromname"
 msgstr ""
 
@@ -152,17 +156,17 @@ msgid "label_cancel"
 msgstr ""
 
 #. Default: "Subsite language"
-#: ./ftw/subsite/content/subsite.py:65
+#: ./ftw/subsite/content/subsite.py:73
 msgid "label_forcelanguage"
 msgstr ""
 
 #. Default: "Email Senderaddress"
-#: ./ftw/subsite/content/subsite.py:79
+#: ./ftw/subsite/content/subsite.py:87
 msgid "label_fromemail"
 msgstr ""
 
 #. Default: "Email Sendername"
-#: ./ftw/subsite/content/subsite.py:73
+#: ./ftw/subsite/content/subsite.py:81
 msgid "label_fromname"
 msgstr ""
 

--- a/ftw/subsite/tests/test_languageswitcher.py
+++ b/ftw/subsite/tests/test_languageswitcher.py
@@ -107,6 +107,27 @@ class TestLanguageswitcher(unittest.TestCase):
             [u'Fran\xe7ais'],
             self.german.absolute_url())
 
+    def test_listing_plone_site_and_language_references_combined(self):
+        self.assertSelectableLanguagesOnPage(
+            [u'Fran\xe7ais'],
+            self.german.absolute_url())
+
+        self.german.setLinkSiteInLanguagechooser(True)
+        transaction.commit()
+
+        self.assertSelectableLanguagesOnPage(
+            [u'Fran\xe7ais', u'English'],
+            self.german.absolute_url())
+
+    def test_listing_only_plone_site(self):
+        self.german.setLinkSiteInLanguagechooser(True)
+        self.german.setLanguage_references([])
+        transaction.commit()
+
+        self.assertSelectableLanguagesOnPage(
+            [u'English'],
+            self.german.absolute_url())
+
     def assertSelectableLanguagesOnPage(self, expected_languages, url):
         self.browser.open(url)
         doc = PyQuery(self.browser.contents)


### PR DESCRIPTION
I've also refactored the tests (separate assertion method) and the language switcher (only lookup navigation root once).

@Tschanzt can you take a look at it?
