### PR TITLE
Do not add class subsiteLogo to logo if there is no subsite logo.

### DIFF
--- a/ftw/subsite/viewlets/subsitelogoviewlet.pt
+++ b/ftw/subsite/viewlets/subsitelogoviewlet.pt
@@ -1,9 +1,9 @@
 <a metal:define-macro="portal_logo"
    id="portal-logo"
-   class="subsiteLogo"
    accesskey="1"
    tal:attributes="href view/navigation_root_url;
-                   title view/title"
+                   title view/title;
+                   class python: view.is_subsitelogo and 'subsiteLogo' or None"
    i18n:domain="plone">
     <img src="logo.jpg" alt=""
          tal:replace="structure view/logo_tag" /></a>

--- a/ftw/subsite/viewlets/subsitelogoviewlet.py
+++ b/ftw/subsite/viewlets/subsitelogoviewlet.py
@@ -13,6 +13,7 @@ class SubsiteLogoViewlet(LogoViewlet):
         self.navigation_root_url = None
         self.logo_tag = None
         self.title = None
+        self.is_subsitelogo = False
 
     def update(self):
         super(SubsiteLogoViewlet, self).update()
@@ -33,6 +34,7 @@ class SubsiteLogoViewlet(LogoViewlet):
             self.logo_tag = scale.scale('logo', scale="logo").tag()
             self.title = self.context.restrictedTraverse(
                 getNavigationRoot(self.context)).Title()
+            self.is_subsitelogo = True
         else:
             # standard plone logo
             logoName = portal.restrictedTraverse('base_properties').logoName


### PR DESCRIPTION
If there is no logo defined in the subsite, the default logo will be displayed.
In this case the logo should not have the class `subsiteLogo`.
@jone do you agree?
