### PR TITLE
Hide banner viewlet from folder_contents when root_only option enabled.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Hide banner viewlet from folder_contents when root_only option enabled.
+  [jone]
 
 
 1.2.0 (2013-07-02)

--- a/ftw/subsite/viewlets/banner_viewlet.py
+++ b/ftw/subsite/viewlets/banner_viewlet.py
@@ -15,7 +15,18 @@ class Banner(common.ViewletBase):
 
     @property
     def available(self):
-        return bool(self.get_banners())
+        if not self.get_banners():
+            return False
+
+        registry = getUtility(IRegistry)
+        root_only = registry.get('ftw.subsite.banner_root_only', True)
+
+        if root_only:
+            context_state = self.context.restrictedTraverse(
+                'plone_context_state')
+            return context_state.is_view_template()
+
+        return True
 
     @instance.memoize
     def get_banners(self):


### PR DESCRIPTION
:construction: 
If the option `root_only` is enabled, the banner viewlet should only be visible on the default view of the navigation root.

Currently it shows up on every view called on the navigation root (folder_contents, sharing, sitemap, etc).
With this change it no longer shows up when on non-default views if `root_only` is enabled.

When `root_only` is not enabled, the banner viewlet is usually placed differently in the theme (e.g. smaller banners) and is visible on every context, thats why it also should show up on views such as folder_contents.

@Tschanzt could you take a look at this change and merge if it is ok?
