### PR TITLE
Add ftw.publisher support for teaser portlet.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.4.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add ftw.publisher support for teaser portlet.
+  [jone]
 
 
 1.4.1 (2015-02-25)

--- a/ftw/subsite/portlets/teaserportlet.py
+++ b/ftw/subsite/portlets/teaserportlet.py
@@ -55,14 +55,20 @@ class Assignment(base.Assignment):
     implements(ITeaserPortlet)
 
     def __init__(self, assignment_context_path=None, teasertitle='',
-                 teaserdesc='', image=None, imagetitle='', internal_target=None):
+                 teaserdesc='', image=None, _image=None,
+                 imagetitle='', internal_target=None, image_timestamp=None):
+
+        # ftw.publisher support
+        if _image:
+            image = _image
+
         self.assignment_context_path = assignment_context_path
         self.teasertitle = teasertitle
         self.teaserdesc = teaserdesc
         self._image = image
         self.imagetitle = imagetitle
         self.internal_target = internal_target
-        self.image_timestamp = DateTime()
+        self.image_timestamp = image_timestamp or DateTime()
 
     @property
     def image(self):

--- a/ftw/subsite/tests/test_subsiteportlet.py
+++ b/ftw/subsite/tests/test_subsiteportlet.py
@@ -187,3 +187,13 @@ class TestSubsite(unittest.TestCase):
             ('content-type', 'image/png'),
             ('cache-control', 'max-age=86400')],
             self.browser.mech_browser.response()._headers.items())
+
+    def test_publisher_support(self):
+        """ftw.publisher does serialization and deserialization with something like:
+        Assignment(**other_assignment.__dict__)
+        """
+
+        assignment = self._create_portlet()
+        assignment_copy = teaserportlet.Assignment(**assignment.__dict__)
+        self.assertTrue(assignment_copy)
+        self.assertEqual(assignment.__dict__, assignment_copy.__dict__)


### PR DESCRIPTION
Assignments are instantiated by the __dict__ of another assignment by ftw.publisher.
/cc @maethu 