### PR TITLE
Enable IReferenceable on all types.

### DIFF
--- a/ftw/subsite/profiles/default/types/ftw.subsite.Subsite.xml
+++ b/ftw/subsite/profiles/default/types/ftw.subsite.Subsite.xml
@@ -38,6 +38,7 @@
         <element value="plone.app.content.interfaces.INameFromTitle" />
         <element value="plone.app.dexterity.behaviors.exclfromnav.IExcludeFromNavigation"/>
         <element value="Products.CMFPlone.interfaces.constrains.ISelectableConstrainTypes"/>
+        <element value="plone.app.referenceablebehavior.referenceable.IReferenceable"/>
     </property>
 
     <!-- View information -->


### PR DESCRIPTION
The IReferenceable behavior adds the objects to the reference catalog.
We need this in order to lookup objects by UUID.