### PR TITLE
Fix traversing for css and banner viewlet.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 2.0.0 (unreleased)
 ------------------
 
+- Prevent traversing to a not accessible navigation root.
+  [mathias.leimgruber]
+
 - Make current language and list of possible languages accessable thru browserview.
   [mathias.leimgruber]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 2.0.0 (unreleased)
 ------------------
 
-- Prevent traversing to a not accessible navigation root.
+- Prevent traversing to a not accessible navigation root in banner and css
+  viewlet.
   [mathias.leimgruber]
 
 - Make current language and list of possible languages accessable thru browserview.

--- a/ftw/subsite/tests/test_bannerviewlet.py
+++ b/ftw/subsite/tests/test_bannerviewlet.py
@@ -2,6 +2,7 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.subsite.interfaces import IFtwSubsiteLayer
 from ftw.subsite.testing import FTW_SUBSITE_INTEGRATION_TESTING
+from plone.app.testing import login
 from plone.registry import Record, field
 from plone.registry.interfaces import IRegistry
 from unittest2 import TestCase
@@ -12,6 +13,7 @@ from zope.interface import alsoProvides
 from zope.publisher.browser import BrowserView
 from zope.viewlet.interfaces import IViewletManager
 import os
+
 
 class TestBannerViewlet(TestCase):
 
@@ -200,7 +202,7 @@ class TestBannerViewlet(TestCase):
         bannerfolder = self._setup_bannerfolder(self.portal)
         subfolder = bannerfolder.get(
             bannerfolder.invokeFactory('Folder', 'subfolder'))
-        subfolder.invokeFactory('Image', 'image1')
+        subfolder.invokeFactory('Image', 'imagFae1')
 
         viewlet = self._get_viewlet(self.portal)
         self.assertTrue(
@@ -213,3 +215,16 @@ class TestBannerViewlet(TestCase):
             viewlet[0].available,
             'Expected viewlet to be available on folder_contents,'
             ' since root_only is disabled.')
+
+    def test_do_not_fail_if_nav_root_is_not_traversable(self):
+        self.portal.portal_workflow.setChainForPortalTypes(
+            ('Folder', 'ftw.subsite.Subsite'),
+            'simple_publication_workflow')
+
+        self._setup_bannerfolder(self.portal)
+        subsite = create(Builder('subsite').titled(u'MySubsite'))
+        subfolder = create(Builder('folder').within(subsite))
+        user = create(Builder('user').with_roles('Manager', on=subfolder))
+
+        login(self.portal, user.getId())
+        self.assertFalse(self._get_viewlet(subfolder)[0].available)

--- a/ftw/subsite/tests/test_bannerviewlet.py
+++ b/ftw/subsite/tests/test_bannerviewlet.py
@@ -202,7 +202,7 @@ class TestBannerViewlet(TestCase):
         bannerfolder = self._setup_bannerfolder(self.portal)
         subfolder = bannerfolder.get(
             bannerfolder.invokeFactory('Folder', 'subfolder'))
-        subfolder.invokeFactory('Image', 'imagFae1')
+        subfolder.invokeFactory('Image', 'image1')
 
         viewlet = self._get_viewlet(self.portal)
         self.assertTrue(

--- a/ftw/subsite/viewlets/banner_viewlet.py
+++ b/ftw/subsite/viewlets/banner_viewlet.py
@@ -28,7 +28,7 @@ class Banner(common.ViewletBase):
 
         return True
 
-    @instance.memoize
+    # @instance.memoize
     def get_banners(self):
         catalog = getToolByName(self.context, 'portal_catalog')
         bannerfolder = self.get_banner_folder()
@@ -54,12 +54,13 @@ class Banner(common.ViewletBase):
 
     def get_banner_folder(self):
         registry = getUtility(IRegistry)
-        nav_context = self.context.restrictedTraverse(
-            getNavigationRoot(self.context)).aq_explicit
 
         name = registry.get('ftw.subsite.bannerfoldername', 'banners')
         bannerfolder = None
         try:
+            nav_context = self.context.restrictedTraverse(
+                getNavigationRoot(self.context)).aq_explicit
+
             bannerfolder = nav_context.restrictedTraverse(name.encode('utf-8'))
         except (KeyError, AttributeError):
             return None

--- a/ftw/subsite/viewlets/banner_viewlet.py
+++ b/ftw/subsite/viewlets/banner_viewlet.py
@@ -28,7 +28,7 @@ class Banner(common.ViewletBase):
 
         return True
 
-    # @instance.memoize
+    @instance.memoize
     def get_banners(self):
         catalog = getToolByName(self.context, 'portal_catalog')
         bannerfolder = self.get_banner_folder()

--- a/ftw/subsite/viewlets/cssviewlet.py
+++ b/ftw/subsite/viewlets/cssviewlet.py
@@ -14,7 +14,7 @@ class CSSViewlet(ViewletBase):
 
     def render(self):
         self.nav_root = self.context.restrictedTraverse(
-            getNavigationRoot(self.context))
+            getNavigationRoot(self.context), None)
         if ISubsite.providedBy(self.nav_root):
             return self.template()
         else:


### PR DESCRIPTION
This prevents spamming the error log from `You are not allowed to access XYZ in this context`