### PR TITLE
Teaserportlet: wrap title into span.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.4.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Teaserportlet: wrap title into span.
+  [jone]
 
 
 1.4.2 (2015-02-27)

--- a/ftw/subsite/portlets/teaserportlet.pt
+++ b/ftw/subsite/portlets/teaserportlet.pt
@@ -6,7 +6,7 @@
     <dt class="portletHeader">
     	<a tal:omit-tag="not: internal_url" tal:attributes="href internal_url">
           <img tal:replace="structure image" />
-          <span class="teaser_title" tal:replace="structure teasertitle" />
+          <span class="teaser_title" tal:content="structure teasertitle" />
     	</a>
     </dt>
     <dd class="portletItem teaserDescription"


### PR DESCRIPTION
Wrapping the title into a span-tag allows to add CSS stylings on the title and to distinguish the title from the img in CSS.