### PR TITLE
Render the subsite logo when adding content.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.4.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Render the subsite logo when creating content.
+  [mbaechtold]
 
 
 1.4.4 (2015-12-23)

--- a/ftw/subsite/testing.py
+++ b/ftw/subsite/testing.py
@@ -19,21 +19,15 @@ class FtwSubsiteIntegrationLayer(PloneSandboxLayer):
     defaultBases = (PLONE_FIXTURE, BUILDER_LAYER)
 
     def setUpZope(self, app, configurationContext):
-        # Load ZCML
-        import ftw.subsite
-        xmlconfig.file('configure.zcml', ftw.subsite,
-                       context=configurationContext)
-
-        xmlconfig.file('overrides.zcml', ftw.subsite,
-                       context=configurationContext)
-
-        import plone.app.portlets
-        xmlconfig.file('configure.zcml', plone.app.portlets,
-                       context=configurationContext)
-
-        import collective.MockMailHost
-        xmlconfig.file('configure.zcml', collective.MockMailHost,
-                       context=configurationContext)
+        xmlconfig.string(
+            '<configure xmlns="http://namespaces.zope.org/zope">'
+            '  <include package="z3c.autoinclude" file="meta.zcml" />'
+            '  <includePlugins package="plone" />'
+            '  <includePluginsOverrides package="plone" />'
+            '  <include package="ftw.subsite.tests" />'
+            '  <include package="collective.MockMailHost" />'
+            '</configure>',
+            context=configurationContext)
 
         # installProduct() is *only* necessary for packages outside
         # the Products.* namespace which are also declared as Zope 2 products,
@@ -46,6 +40,8 @@ class FtwSubsiteIntegrationLayer(PloneSandboxLayer):
         # Install into Plone site using portal_setup
         applyProfile(portal, 'ftw.subsite:default')
         applyProfile(portal, 'collective.MockMailHost:default')
+        applyProfile(portal, 'plone.app.dexterity:default')
+        applyProfile(portal, 'ftw.subsite.tests:dx_creation')
         setRoles(portal, TEST_USER_ID, ['Manager'])
         login(portal, TEST_USER_NAME)
 

--- a/ftw/subsite/tests/builders.py
+++ b/ftw/subsite/tests/builders.py
@@ -1,5 +1,7 @@
 from ftw.builder.archetypes import ArchetypesBuilder
 from ftw.builder import builder_registry
+from ftw.builder.dexterity import DexterityBuilder
+import os
 
 
 class SubsiteBuilder(ArchetypesBuilder):
@@ -13,5 +15,19 @@ class SubsiteBuilder(ArchetypesBuilder):
         else:
             return self.having(forcelanguage=language_code)
 
+    def with_dummy_logo(self):
+        png_file = os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            'blue.png',
+        )
+        logo = open(png_file, 'r')
+        self.arguments['logo'] = logo
+        return self
 
 builder_registry.register('subsite', SubsiteBuilder)
+
+
+class ExampleDxTypeBuilder(DexterityBuilder):
+    portal_type = 'ExampleDxType'
+
+builder_registry.register('example dx type', ExampleDxTypeBuilder)

--- a/ftw/subsite/tests/configure.zcml
+++ b/ftw/subsite/tests/configure.zcml
@@ -1,0 +1,17 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    i18n_domain="ftw.subsite">
+
+    <include package="zope.i18n" file="meta.zcml" />
+    <include package="Products.GenericSetup" file="meta.zcml" />
+
+    <genericsetup:registerProfile
+        name="dx_creation"
+        title="ftw.subsite.tests:dx_creation"
+        directory="profiles/dx_creation"
+        description=""
+        provides="Products.GenericSetup.interfaces.EXTENSION"
+        />
+
+</configure>

--- a/ftw/subsite/tests/contents.py
+++ b/ftw/subsite/tests/contents.py
@@ -1,0 +1,7 @@
+from ftw.subsite.tests.interfaces import IExampleDxType
+from plone.dexterity.content import Item
+from zope.interface import implements
+
+
+class ExampleDxType(Item):
+    implements(IExampleDxType)

--- a/ftw/subsite/tests/interfaces.py
+++ b/ftw/subsite/tests/interfaces.py
@@ -1,0 +1,5 @@
+from zope.interface import Interface
+
+
+class IExampleDxType(Interface):
+    pass

--- a/ftw/subsite/tests/profiles/dx_creation/types.xml
+++ b/ftw/subsite/tests/profiles/dx_creation/types.xml
@@ -1,0 +1,3 @@
+<object name="portal_types">
+    <object name="ExampleDxType" meta_type="Dexterity FTI" />
+</object>

--- a/ftw/subsite/tests/profiles/dx_creation/types/ExampleDxType.xml
+++ b/ftw/subsite/tests/profiles/dx_creation/types/ExampleDxType.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+<object name="ExampleDxType"
+        meta_type="Dexterity FTI"
+        xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+        i18n:domain="ftw.subsite.tests" >
+
+    <!-- Basic metadata -->
+    <property name="title">ExampleDxType</property>
+    <property name="global_allow">True</property>
+    <property name="add_permission">cmf.AddPortalContent</property>
+
+    <!-- schema interface -->
+    <property name="schema">ftw.subsite.tests.interfaces.IExampleDxType</property>
+
+    <!-- class used for content items -->
+    <property name="klass">ftw.subsite.tests.contents.ExampleDxType</property>
+
+    <!-- enabled behaviors -->
+    <property name="behaviors">
+        <element value="plone.app.dexterity.behaviors.metadata.IBasic" />
+        <element value="plone.app.content.interfaces.INameFromTitle" />
+    </property>
+
+    <!-- View information -->
+    <property name="default_view">view</property>
+    <property name="default_view_fallback">False</property>
+    <property name="view_methods">
+        <element value="view"/>
+    </property>
+
+    <!-- Method aliases -->
+    <alias from="(Default)" to="(dynamic view)"/>
+    <alias from="edit" to="@@edit"/>
+    <alias from="sharing" to="@@sharing"/>
+    <alias from="view" to="(selected layout)"/>
+
+    <!-- Actions -->
+    <action
+        action_id="view"
+        title="View"
+        category="object"
+        condition_expr=""
+        url_expr="string:${object_url}"
+        visible="True">
+        <permission value="View"/>
+    </action>
+
+    <action
+        action_id="edit"
+        title="Edit"
+        category="object"
+        condition_expr=""
+        url_expr="string:${object_url}/edit"
+        visible="True">
+        <permission value="Modify portal content"/>
+    </action>
+
+</object>

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ tests_require = [
     'ftw.builder',
     'ftw.testbrowser',
     'ftw.testing [splinter]',
+    'plone.app.dexterity',
     'plone.app.portlets',
     'plone.app.testing',
     'pyquery',


### PR DESCRIPTION
This fixes a problem where the subsite logo was not rendered when adding content below a subsite. The Plone default logo was rendered instead.