### PR TITLE
Add german translations for contact view

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 2.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add german translations for "contact-info" view.
+  [raphael-s]
 
 
 2.0.1 (2016-04-11)

--- a/ftw/subsite/locales/de/LC_MESSAGES/ftw.subsite.po
+++ b/ftw/subsite/locales/de/LC_MESSAGES/ftw.subsite.po
@@ -96,7 +96,7 @@ msgstr ""
 #. Default: "Please enter your Name"
 #: ./ftw/subsite/browser/contact.py:23
 msgid "help_Sender"
-msgstr ""
+msgstr "Bitte geben Sie Ihren Namen ein"
 
 #: ./ftw/subsite/content/subsite.py:39
 #: ./ftw/subsite/content/subsitedx.py:59
@@ -133,17 +133,17 @@ msgstr ""
 #. Default: "Please enter your e-mail"
 #: ./ftw/subsite/browser/contact.py:26
 msgid "help_mail_address"
-msgstr ""
+msgstr "Bitte geben Sie Ihre e-Mail ein"
 
 #. Default: "Please enter a Message"
 #: ./ftw/subsite/browser/contact.py:32
 msgid "help_message"
-msgstr ""
+msgstr "Bitte geben Sie eine Nachricht ein"
 
 #. Default: "Please enter a Subject"
 #: ./ftw/subsite/browser/contact.py:29
 msgid "help_subject"
-msgstr ""
+msgstr "Bitte geben Sie ein Thema ein"
 
 #. Default: "The email was sent."
 #: ./ftw/subsite/browser/contact.py:52


### PR DESCRIPTION
Adds german translations for the `contact-info` view.

![bildschirmfoto 2016-05-30 um 13 39 17](https://cloud.githubusercontent.com/assets/16755391/15648607/ebfd95e8-266b-11e6-88f9-d20fc7eb3708.png)

closes #77 