### PR TITLE
Remove invalid aria attributes from section and header tag in languageselector.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 2.0.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Remove invalid aria attributes from section and header tag in languageselector.
+  [mathias.leimgruber]
 
 
 2.0.2 (2016-05-30)

--- a/ftw/subsite/browser/languageselector.pt
+++ b/ftw/subsite/browser/languageselector.pt
@@ -5,11 +5,10 @@
 
     <h2 i18n:translate="" class="hiddenStructure">Language switch</h2>
 
-    <section id="portal-languageselector" role="menubar" class="actionMenu deactivated">
+    <section id="portal-languageselector" class="actionMenu deactivated">
 
         <header class="actionMenuHeader"
             tal:define="current view/current"
-            role="menuitem"
             aria-haspopup="true"
             aria-owns="languageselector-content"
             aria-controls="languageselector-content">


### PR DESCRIPTION
w3c validator complains about it.

