### PR TITLE
Fix dependency-error if ftw.subsite is installed with ftw.theming but without ftw.mobile.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,9 @@ Changelog
 2.0.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix dependency-error if ftw.subsite is installed with ftw.theming but without ftw.mobile.
+  Only loads mobilenavigation-specific scss if ftw.mobile and ftw.theming are installed.
+  [elioschmutz]
 
 
 2.0.3 (2016-06-10)

--- a/ftw/subsite/browser/ressources/integration.ftw-mobile.theme.scss
+++ b/ftw/subsite/browser/ressources/integration.ftw-mobile.theme.scss
@@ -1,0 +1,24 @@
+/* This file is only used when ftw.theming and ftw.mobile is installed. */
+
+#subsitelanguage-mobile-button {
+  a {
+    @include auto-text-color($color-mobile-button);
+    background-color: $color-mobile-button;
+    display: inline-block;
+    width: $size-mobile-button;
+    line-height: $size-mobile-button;
+    font-size: $font-size-mobile-button;
+    text-align: center;
+    &:before {
+      display: none;
+    }
+  }
+}
+
+#portal-languageselector-wrapper #portal-languageselector{
+  display: none;
+
+  @include tablet {
+    display: block;
+  }
+}

--- a/ftw/subsite/browser/ressources/integration.theme.scss
+++ b/ftw/subsite/browser/ressources/integration.theme.scss
@@ -1,27 +1,3 @@
 /* This file is only used when ftw.theming is installed. */
 
 @include portal-type-font-awesome-icon(ftw-subsite-subsite, globe);
-
-
-#subsitelanguage-mobile-button {
-  a {
-    @include auto-text-color($color-mobile-button);
-    background-color: $color-mobile-button;
-    display: inline-block;
-    width: $size-mobile-button;
-    line-height: $size-mobile-button;
-    font-size: $font-size-mobile-button;
-    text-align: center;
-    &:before {
-      display: none;
-    }
-  }
-}
-
-#portal-languageselector-wrapper #portal-languageselector{
-  display: none;
-
-  @include tablet {
-    display: block;
-  }
-}

--- a/ftw/subsite/resources.zcml
+++ b/ftw/subsite/resources.zcml
@@ -1,12 +1,14 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
     xmlns:theme="http://namespaces.zope.org/ftw.theming"
+    xmlns:zcml="http://namespaces.zope.org/zcml"
     i18n_domain="ftw.subsite">
 
     <include package="ftw.theming" file="meta.zcml" />
 
     <theme:resources profile="ftw.subsite:default" slot="addon">
         <theme:scss file="browser/ressources/integration.theme.scss" after="ftw.mobile:scss/mobile-buttons.scss" />
+        <theme:scss file="browser/ressources/integration.ftw-mobile.theme.scss" after="browser/ressources/integration.theme.scss" zcml:condition="installed ftw.mobile" />
     </theme:resources>
 
 </configure>


### PR DESCRIPTION
Fix dependency-error if ftw.subsite is installed with ftw.theming but without ftw.mobile.

Only loads mobilenavigation-specific scss if ftw.mobile and ftw.theming are installed.