### PR TITLE
Change name of simplelayout-view

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 2.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Remove "@@" from simplelayout-view because it is not needed.
+  [raphael-s]
 
 
 2.1.0 (2016-07-20)

--- a/ftw/subsite/profiles/default/types/ftw.subsite.Subsite.xml
+++ b/ftw/subsite/profiles/default/types/ftw.subsite.Subsite.xml
@@ -40,10 +40,10 @@
     </property>
 
     <!-- View information -->
-    <property name="default_view">@@simplelayout-view</property>
+    <property name="default_view">simplelayout-view</property>
     <property name="default_view_fallback">False</property>
     <property name="view_methods">
-        <element value="@@simplelayout-view"/>
+        <element value="simplelayout-view"/>
     </property>
 
     <!-- Method aliases -->

--- a/ftw/subsite/upgrades/20160816105837_rename_simple_layout_view/types/ftw.subsite.Subsite.xml
+++ b/ftw/subsite/upgrades/20160816105837_rename_simple_layout_view/types/ftw.subsite.Subsite.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<object name="ftw.subsite.Subsite"
+        meta_type="Dexterity FTI"
+        xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+        i18n:domain="ftw.subsite" >
+
+    <!-- View information -->
+    <property name="default_view" purge="False">simplelayout-view</property>
+    <property name="view_methods" purge="False">
+        <element value="simplelayout-view"/>
+    </property>
+</object>

--- a/ftw/subsite/upgrades/20160816105837_rename_simple_layout_view/upgrade.py
+++ b/ftw/subsite/upgrades/20160816105837_rename_simple_layout_view/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class RenameSimpleLayoutView(UpgradeStep):
+    """Rename simple layout view.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
Removes `@@` from the simplelayout-view, because it is not needed. 
Also includes an upgrade step for the changes.

closes #84