### PR TITLE
Make Subsite linkable in TinyMCE

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -10,6 +10,9 @@ Changelog
 - Reimplement AT=>DX migration with inplace migrator introduced in
   ftw.upgrade 2.0.0. [jone]
 
+- Make ftw.subsite.Subsite linkable in TinyMCE.
+  [raphael-s]
+
 - Remove "@@" from simplelayout-view because it is not needed.
   [raphael-s]
 

--- a/ftw/subsite/profiles/default/tinymce.xml
+++ b/ftw/subsite/profiles/default/tinymce.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<object>
+  <resourcetypes>
+    <linkable purge="False">
+      <element value="ftw.subsite.Subsite" />
+    </linkable>
+  </resourcetypes>
+</object>

--- a/ftw/subsite/upgrades/20160816161334_make_subsite_linkable/tinymce.xml
+++ b/ftw/subsite/upgrades/20160816161334_make_subsite_linkable/tinymce.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<object>
+  <resourcetypes>
+    <linkable purge="False">
+      <element value="ftw.subsite.Subsite" />
+    </linkable>
+  </resourcetypes>
+</object>

--- a/ftw/subsite/upgrades/20160816161334_make_subsite_linkable/upgrade.py
+++ b/ftw/subsite/upgrades/20160816161334_make_subsite_linkable/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class MakeSubsiteLinkable(UpgradeStep):
+    """Make subsite linkable.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
Adds `ftw.subsite.Subsite` to the new TinyMCE config. This makes the type linkable in the editor.

closes #85 