### PR TITLE
Redefine ftw.mobile dependency

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 2.4.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Prevent mobile customizations from loading when ftw.mobile is not installed.
+  [raphael-s]
 
 
 2.4.0 (2016-10-17)

--- a/ftw/subsite/resources.zcml
+++ b/ftw/subsite/resources.zcml
@@ -8,9 +8,14 @@
 
     <theme:resources profile="ftw.subsite:default" slot="addon">
         <theme:scss file="browser/ressources/integration.theme.scss" />
-        <theme:scss file="browser/ressources/integration.ftw-mobile.theme.scss"
-                    after="ftw.mobile:scss/mobile-menu-buttons.scss"
-                    zcml:condition="installed ftw.mobile" />
     </theme:resources>
+
+    <configure zcml:condition="installed ftw.mobile">
+        <theme:resources profile="ftw.subsite:default" slot="addon"
+                         layer="ftw.mobile.interfaces.IMobileLayer">
+            <theme:scss file="browser/ressources/integration.ftw-mobile.theme.scss"
+                        after="ftw.mobile:scss/mobile-menu-buttons.scss" />
+        </theme:resources>
+    </configure>
 
 </configure>


### PR DESCRIPTION
This prevents us from sass compilation error if ftw.subsite is installed and ftw.mobile only in the PATH.

Fixes #95 
