### PR TITLE
Make subsitelogoviewlet more robust

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 2.4.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Make subsitelogoviewlet and the fallback logo more robust.
+  [raphael-s]
 
 
 2.4.2 (2016-11-28)

--- a/ftw/subsite/tests/builders.py
+++ b/ftw/subsite/tests/builders.py
@@ -1,5 +1,6 @@
 from ftw.builder.dexterity import DexterityBuilder
 from ftw.builder import builder_registry
+from ftw.simplelayout.tests import builders
 
 
 class SubsiteBuilder(DexterityBuilder):

--- a/ftw/subsite/tests/test_subsiteviewletlogo.py
+++ b/ftw/subsite/tests/test_subsiteviewletlogo.py
@@ -144,3 +144,13 @@ class TestLogoViewlet(TestCase):
             u'Plone Logo Alt Text',
             browser.css('#portal-logo img').first.attrib['alt'])
 
+    @browsing
+    def test_logo_with_other_content_with_id_logo(self, browser):
+        self._add_logo(self.subsite)
+
+        contentpage = create(Builder('sl content page').within(self.subsite))
+        create(Builder('sl textblock').titled('logo').within(contentpage))
+
+        browser.login().visit(contentpage)
+
+        self.assertTrue(browser.css('#portal-logo img'))

--- a/ftw/subsite/viewlets/subsitelogoviewlet.py
+++ b/ftw/subsite/viewlets/subsitelogoviewlet.py
@@ -24,8 +24,8 @@ class SubsiteLogoViewlet(LogoViewlet):
 
         self.navigation_root_url = self.portal_state.navigation_root_url()
 
-        subsite_logo = getattr(self.context, 'logo', None)
-        subsite_logo_alt_text = getattr(self.context, 'logo_alt_text', None)
+        subsite_logo = getattr(navroot, 'logo', None)
+        subsite_logo_alt_text = getattr(navroot, 'logo_alt_text', None)
 
         if is_subsite and subsite_logo and subsite_logo.data:
             # we are in a subsite
@@ -43,8 +43,9 @@ class SubsiteLogoViewlet(LogoViewlet):
             self.is_subsitelogo = True
         else:
             # standard plone logo
+            portal = api.portal.get()
             logoName = navroot.restrictedTraverse('base_properties').logoName
-            logo_alt_text = navroot.getProperty('logo_alt_text', '')
-            self.logo_tag = navroot.restrictedTraverse(logoName).tag(
+            logo_alt_text = portal.getProperty('logo_alt_text', '')
+            self.logo_tag = portal.restrictedTraverse(logoName).tag(
                 alt=logo_alt_text, title='')
             self.title = self.portal_state.portal_title()


### PR DESCRIPTION
Fixes some previous mistakes I made in #99 

`subsitelogoviewlet` should now be protected against any troubles caused by other content with the id `logo`

closes #98 