### PR TITLE
Make Subsite addable on plone site

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2.4.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Make Subsite addable on plone site per default [raphael-s]
 
 
 2.4.3 (2016-11-29)

--- a/ftw/subsite/profiles/default/types/Plone_Site.xml
+++ b/ftw/subsite/profiles/default/types/Plone_Site.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<object name="Plone Site">
+
+    <property name="allowed_content_types" purge="False">
+        <element value="ftw.subsite.Subsite" />
+    </property>
+
+</object>


### PR DESCRIPTION
When `ftw.subsite` is installed Subsites can now be added to plone site per default.

We don't want an upgrade step for this because we don't want to change how existing deployments handle Subsites.