### PR TITLE
Remove dependency on ftw.testing[splinter]

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2.4.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Remove dependency on ftw.testing[splinter] (has been dropped in ftw.testing). [lgraf]
 
 
 2.4.4 (2017-03-07)

--- a/ftw/subsite/testing.py
+++ b/ftw/subsite/testing.py
@@ -1,17 +1,17 @@
 from ftw.builder.testing import BUILDER_LAYER
 from ftw.builder.testing import functional_session_factory
 from ftw.builder.testing import set_builder_session_factory
-from ftw.testing import FunctionalSplinterTesting
+from plone.app.testing import applyProfile
+from plone.app.testing import FunctionalTesting
 from plone.app.testing import IntegrationTesting
+from plone.app.testing import login
 from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PloneSandboxLayer
 from plone.app.testing import TEST_USER_ID, setRoles
 from plone.app.testing import TEST_USER_NAME
-from plone.app.testing import applyProfile
-from plone.app.testing import login
 from plone.testing import z2
 from zope.configuration import xmlconfig
-import ftw.subsite.tests.builders
+import ftw.subsite.tests.builders  # noqa
 
 
 class FtwSubsiteIntegrationLayer(PloneSandboxLayer):
@@ -73,13 +73,13 @@ class FtwSubsiteWithoutApplyProfileLayer(FtwSubsiteIntegrationLayer):
 FTW_SUBSITE_FIXTURE = FtwSubsiteIntegrationLayer()
 FTW_SUBSITE_INTEGRATION_TESTING = IntegrationTesting(
     bases=(FTW_SUBSITE_FIXTURE,), name="FtwSubsite:Integration")
-FTW_SUBSITE_FUNCTIONAL_TESTING = FunctionalSplinterTesting(
+FTW_SUBSITE_FUNCTIONAL_TESTING = FunctionalTesting(
     bases=(FTW_SUBSITE_FIXTURE,
            set_builder_session_factory(functional_session_factory)),
     name="FtwSubsite:Functional")
 
 FTW_SUBSITE_SPECIAL_FIXTURE = FtwSubsiteWithoutApplyProfileLayer()
-FTW_SUBSITE_SPECIAL_FUNCTIONAL_TESTING = FunctionalSplinterTesting(
+FTW_SUBSITE_SPECIAL_FUNCTIONAL_TESTING = FunctionalTesting(
     bases=(FTW_SUBSITE_SPECIAL_FIXTURE,
            set_builder_session_factory(functional_session_factory)),
     name="FtwSubsite:SpecialFunctional")

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ version = '2.4.5.dev0'
 tests_require = [
     'collective.mockmailhost',
     'ftw.builder',
-    'ftw.testing [splinter]',
+    'ftw.testing',
     'plone.app.portlets',
     'plone.app.testing',
     'pyquery',


### PR DESCRIPTION
This removes the dependency on the `ftw.testing[splinter]` extra, which has been [dropped from 
`ftw.testing`](https://github.com/4teamwork/ftw.testing/commit/6eadb49bed08a0b40113d65abf8b302935cb1007).