### PR TITLE
Adapt utf8 encoding in mailer

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ------------------
 
 - Add ImageMagic dependency comment to readme. [busykoala]
+- Change mailer encoding from win cp-1252 to utf-8 and refactor mailer. [busykoala]
 
 
 2.6.0 (2019-06-26)

--- a/ftw/subsite/browser/contact.py
+++ b/ftw/subsite/browser/contact.py
@@ -4,6 +4,7 @@ from email.header import Header
 from email.mime.text import MIMEText
 from ftw.subsite import _
 from plone.app.layout.navigation.root import getNavigationRoot
+from plone.dexterity.utils import safe_utf8
 from z3c.form import form, field, button
 from z3c.form.validator import SimpleFieldValidator
 from z3c.form.validator import WidgetValidatorDiscriminators
@@ -69,7 +70,6 @@ class ContactForm(form.Form):
     def send_feedback(self, recipient, subject, message, sender):
         """Send a feedback email to the email address defined in subsite.
         """
-        mh = getToolByName(self.context, 'MailHost')
         portal = getToolByName(self.context, 'portal_url').getPortalObject()
         nav_root = None
         if not '/'.join(portal.getPhysicalPath()) == getNavigationRoot(self.context):
@@ -82,7 +82,7 @@ class ContactForm(form.Form):
             site_title = portal.Title()
             site_url = portal.absolute_url()
 
-        text = translate(
+        message = translate(
             u'feedback_mail_text',
             domain='ftw.subsite',
             default='${sender} sends you a message from your site ${site_title}(${site_url}):\n${msg}',
@@ -91,10 +91,6 @@ class ContactForm(form.Form):
                      'msg': message,
                      'site_title': site_title,
                      'site_url': site_url})
-
-        # create the message root with from, to, and subject headers
-        msg = MIMEText(text.encode('windows-1252'), 'plain', 'windows-1252')
-        msg['Subject'] = Header(subject, 'windows-1252')
 
         default_from_name = portal.getProperty('email_from_name', '')
         default_from_email = portal.getProperty('email_from_address', '')
@@ -105,12 +101,6 @@ class ContactForm(form.Form):
         else:
             email_from_name = default_from_name
             email_from_email = default_from_email
-        msg['From'] = "%s <%s>" % (
-            email_from_name,
-            email_from_email
-        )
-
-        msg['reply-to'] = "%s <%s>" % (sender, recipient)
 
         if IS_PLONE_5:
             from plone import api
@@ -121,9 +111,28 @@ class ContactForm(form.Form):
                 # if none is registered on the page in plone5
                 from_email_field._set_value('site@nohost.com')
                 email_from_email = from_email_field.value
+
         # send the message
-        mh.send(msg, mto=email_from_email,
-                mfrom=[email_from_email])
+        self.send_mail(email_from_name, email_from_email, email_from_email,
+                       subject, message, recipient, sender)
+
+    def send_mail(self, name_from, mail_from, mail_to, mail_subject,
+                  message_text, reply_mail, reply_name):
+        """Send mail using plone mailhost (all input strings need to be utf-8).
+        """
+        if not name_from:
+            name_from = ''
+        # Put together the mail parts
+        msg = MIMEText(message_text.encode('windows-1252'),
+                       'plain', 'windows-1252')
+        msg['From'] = "%s <%s>" % (name_from, mail_from)
+        msg['To'] = safe_utf8(mail_to)
+        msg['Subject'] = Header(mail_subject, 'windows-1252')
+        msg['reply-to'] = '{} <{}>'.format(reply_name, reply_name)
+
+        # Get mailhost and send to mail_to
+        mailhost = getToolByName(self.context, 'MailHost')
+        mailhost.send(msg)
 
 
 class AddressesValidator(SimpleFieldValidator):

--- a/ftw/subsite/browser/contact.py
+++ b/ftw/subsite/browser/contact.py
@@ -85,7 +85,7 @@ class ContactForm(form.Form):
         message = translate(
             u'feedback_mail_text',
             domain='ftw.subsite',
-            default='${sender} sends you a message from your site ${site_title}(${site_url}):\n${msg}',
+            default='${sender} sends you a message from your site ${site_title} (${site_url}):\n${msg}',
             context=self.request,
             mapping={'sender': "%s (%s)" % (sender, recipient),
                      'msg': message,

--- a/ftw/subsite/browser/contact.py
+++ b/ftw/subsite/browser/contact.py
@@ -128,12 +128,13 @@ class ContactForm(form.Form):
         if not name_from:
             name_from = ''
         # Put together the mail parts
-        msg = MIMEText(message_text.encode('windows-1252'),
-                       'plain', 'windows-1252')
-        msg['From'] = "%s <%s>" % (name_from, mail_from)
+        msg = MIMEText(safe_utf8(message_text), 'plain', 'utf-8')
+        msg['From'] = '{} <{}>'.format(safe_utf8(name_from),
+                                       safe_utf8(mail_from))
         msg['To'] = safe_utf8(mail_to)
-        msg['Subject'] = Header(mail_subject, 'windows-1252')
-        msg['reply-to'] = '{} <{}>'.format(reply_name, reply_name)
+        msg['Subject'] = Header(safe_utf8(mail_subject), 'utf-8')
+        msg['reply-to'] = '{} <{}>'.format(safe_utf8(reply_name),
+                                           safe_utf8(reply_mail))
 
         # Get mailhost and send to mail_to
         mailhost = getToolByName(self.context, 'MailHost')

--- a/ftw/subsite/browser/contact.py
+++ b/ftw/subsite/browser/contact.py
@@ -112,6 +112,11 @@ class ContactForm(form.Form):
                 from_email_field._set_value('site@nohost.com')
                 email_from_email = from_email_field.value
 
+            email_from_email = (email_from_email or
+                                reg._records.get('plone.email_from_address').value)
+            email_from_name = (email_from_name or
+                               reg._records.get('plone.email_from_name').value)
+
         # send the message
         self.send_mail(email_from_name, email_from_email, email_from_email,
                        subject, message, recipient, sender)

--- a/ftw/subsite/tests/test_contact.py
+++ b/ftw/subsite/tests/test_contact.py
@@ -2,7 +2,7 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.subsite.testing import FTW_SUBSITE_FUNCTIONAL_TESTING
 from ftw.testbrowser import browsing
-from ftw.testbrowser.pages import statusmessages
+from ftw.testing import IS_PLONE_5
 from unittest2 import TestCase
 import email
 import transaction
@@ -33,10 +33,10 @@ class TestContactFrom(TestCase):
         self.assertEqual(len(mh.messages), 1)
 
         msg = email.message_from_string(mh.messages[0])
-        self.assertEqual(msg.get('From'), 'blubber@blubb.ch')
+        self.assertEqual(msg.get('From'), 'Subsite <blubber@blubb.ch>')
         self.assertEqual(msg.get('reply-to'), u'hans peter <test@test.com>')
         sub = msg.get('Subject')
-        self.assertEqual(sub.encode('utf8'), 'Testsubject')
+        self.assertEqual(sub.encode('utf8'), '=?utf-8?q?Testsubject?=')
         self.assertEqual(
             ('hans peter (test@test.com) sends you a message from your site '
              'Subsite(http:=\n//nohost/plone/subsite):\n'
@@ -69,11 +69,15 @@ class TestContactFrom(TestCase):
         self.assertEqual(len(mh.messages), 1)
 
         msg = email.message_from_string(mh.messages[0])
-        self.assertEqual(msg.get('From'), 'site@nohost.com')
+        if IS_PLONE_5:
+            self.assertEqual(msg.get('From'), '<site@nohost.com>')
+        else:
+            self.assertEqual(msg.get('From'), 'Ploneroot <site@nohost.com>')
+
         self.assertEqual(msg.get('reply-to'), u'hans peter <test@test.com>')
 
         sub = msg.get('Subject')
-        self.assertEqual(sub.encode('utf8'), 'Testsubject')
+        self.assertEqual(sub.encode('utf8'), '=?utf-8?q?Testsubject?=')
         self.assertEqual(
             ('hans peter (test@test.com) sends you a message from your site '
              'Test(http://n=\nohost/plone):\n'

--- a/ftw/subsite/tests/test_contact.py
+++ b/ftw/subsite/tests/test_contact.py
@@ -39,7 +39,7 @@ class TestContactFrom(TestCase):
         self.assertEqual(sub.encode('utf8'), '=?utf-8?q?Testsubject?=')
         self.assertEqual(
             ('hans peter (test@test.com) sends you a message from your site '
-             'Subsite(http:=\n//nohost/plone/subsite):\n'
+             'Subsite (http=\n://nohost/plone/subsite):\n'
              'Lorem ipsum dolor sit amet'),
             msg.get_payload())
 
@@ -80,7 +80,7 @@ class TestContactFrom(TestCase):
         self.assertEqual(sub.encode('utf8'), '=?utf-8?q?Testsubject?=')
         self.assertEqual(
             ('hans peter (test@test.com) sends you a message from your site '
-             'Test(http://n=\nohost/plone):\n'
+             'Test (http://=\nnohost/plone):\n'
              'Lorem ipsum dolor sit amet'),
             msg.get_payload())
 

--- a/sources.cfg
+++ b/sources.cfg
@@ -3,8 +3,3 @@ extends = http://plonesource.org/sources.cfg
 extensions = mr.developer
 
 auto-checkout =
-    ftw.mobile
-    ftw.referencewidget
-
-[branches]
-ftw.mobile = plone51


### PR DESCRIPTION
Close https://github.com/4teamwork/ogb/issues/6

Mostly because of an issue in outlook 2013 where the encoding header
was displayed in the reply-to field, I adapted the utf-8 encoding here. Also I extracted the
actual sender of the email so that I could better debug.