### PR TITLE
Full uninstall profiles for plone 4 / 5

### DIFF
--- a/ftw/subsite/Extensions/install.py
+++ b/ftw/subsite/Extensions/install.py
@@ -1,0 +1,8 @@
+from Products.CMFCore.utils import getToolByName
+
+
+def uninstall(self):
+    setup_tool = getToolByName(self, 'portal_setup')
+    setup_tool.runAllImportStepsFromProfile(
+        'profile-ftw.subsite:uninstall',
+        ignore_dependencies=True)

--- a/ftw/subsite/configure.zcml
+++ b/ftw/subsite/configure.zcml
@@ -55,6 +55,15 @@
         for="Products.CMFPlone.interfaces.IMigratingPloneSiteRoot"
         />
 
+    <genericsetup:registerProfile
+        zcml:condition="not-have plone-5"
+        name="uninstall"
+        title="Uninstall ftw.subsite"
+        directory="profiles/uninstall"
+        provides="Products.GenericSetup.interfaces.EXTENSION"
+        for="Products.CMFPlone.interfaces.IMigratingPloneSiteRoot"
+        />
+
    <profilehook:hook
         zcml:condition="have plone-5"
         profile="ftw.subsite:uninstall"

--- a/ftw/subsite/configure.zcml
+++ b/ftw/subsite/configure.zcml
@@ -2,6 +2,7 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:five="http://namespaces.zope.org/five"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    xmlns:profilehook="http://namespaces.zope.org/profilehook"
     xmlns:i18n="http://namespaces.zope.org/i18n"
     xmlns:zcml="http://namespaces.zope.org/zcml"
     i18n_domain="ftw.subsite">
@@ -9,6 +10,7 @@
   <five:registerPackage package="." initialize=".initialize" />
 
   <include package="z3c.autoinclude" file="meta.zcml" />
+  <include package="ftw.profilehook" />
   <includeDependencies package="." />
 
   <include package="Products.CMFCore" file="permissions.zcml" />
@@ -53,6 +55,11 @@
         for="Products.CMFPlone.interfaces.IMigratingPloneSiteRoot"
         />
 
+   <profilehook:hook
+        zcml:condition="have plone-5"
+        profile="ftw.subsite:uninstall"
+        handler=".profilehooks.uninstall_plone5"
+        />
   <include package=".upgrades" />
 
     <utility

--- a/ftw/subsite/profilehooks.py
+++ b/ftw/subsite/profilehooks.py
@@ -1,0 +1,19 @@
+from plone.registry.interfaces import IRegistry
+from zope.component import getUtility
+
+
+def uninstall_plone5(portal):
+    clean_plone5_registry(portal)
+
+
+def clean_plone5_registry(portal):
+    registry = getUtility(IRegistry)
+
+    allowed_sizes = registry['plone.allowed_sizes']
+    allowed_sizes.remove(u'bannerimage 960:130')
+    allowed_sizes.remove(u'logo 215:56')
+    registry['plone.allowed_sizes'] = allowed_sizes
+
+    displayed_types = list(registry['plone.displayed_types'])
+    displayed_types.remove(u'ftw.subsite.Subsite')
+    registry['plone.displayed_types'] = tuple(displayed_types)

--- a/ftw/subsite/profiles/uninstall/actions.xml
+++ b/ftw/subsite/profiles/uninstall/actions.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<object name="portal_actions" xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+
+  <object name="object" meta_type="CMF Action Category">
+    <object name="manage_portlets" remove="True"></object>
+  </object>
+
+  <object name="site_actions">
+    <object name="contact" i18n:domain="plone">
+      <!-- Reset to plone default instead of "@@contact-info" use "contact-info" -->
+      <property name="title" i18n:translate="">Contact</property>
+      <property name="description" i18n:translate=""></property>
+      <property name="url_expr">string:${globals_view/navigationRootUrl}/contact-info</property>
+      <property name="icon_expr"></property>
+      <property name="available_expr"></property>
+      <property name="permissions">
+        <element value="View"/>
+      </property>
+      <property name="visible">True</property>
+    </object>
+  </object>
+
+</object>

--- a/ftw/subsite/profiles/uninstall/browserlayer.xml
+++ b/ftw/subsite/profiles/uninstall/browserlayer.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<layers>
+ <layer name="ftw_subsite"
+        remove="True"
+        interface="ftw.subsite.interfaces.IFtwSubsiteLayer" />
+</layers>

--- a/ftw/subsite/profiles/uninstall/cssregistry.xml
+++ b/ftw/subsite/profiles/uninstall/cssregistry.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<object name="portal_css">
+  <stylesheet id="++resource++ftw.subsite-resources/subsite.css" remove="True" />
+</object>

--- a/ftw/subsite/profiles/uninstall/propertiestool.xml
+++ b/ftw/subsite/profiles/uninstall/propertiestool.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<object name="portal_properties">
+  <object name="imaging_properties">
+    <property name="allowed_sizes" type="lines" purge="False">
+      <element remove="True" value="bannerimage 960:130"/>
+      <element remove="True" value="logo 215:56"/>
+    </property>
+  </object>
+</object>

--- a/ftw/subsite/profiles/uninstall/registry.xml
+++ b/ftw/subsite/profiles/uninstall/registry.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<registry>
+  <record name="ftw.subsite.banner_root_only" remove="True" />
+  <record name="ftw.subsite.bannerfoldername" remove="True" />
+</registry>

--- a/ftw/subsite/profiles/uninstall/rolemap.xml
+++ b/ftw/subsite/profiles/uninstall/rolemap.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<rolemap>
+  <permissions>
+    <permission name="ftw.subsite: Add Subsite" acquire="True" />
+  </permissions>
+</rolemap>

--- a/ftw/subsite/profiles/uninstall/tinymce.xml
+++ b/ftw/subsite/profiles/uninstall/tinymce.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<object>
+  <resourcetypes>
+    <linkable purge="False">
+      <element value="ftw.subsite.Subsite" remove="True" />
+    </linkable>
+  </resourcetypes>
+</object>

--- a/ftw/subsite/profiles/uninstall/types.xml
+++ b/ftw/subsite/profiles/uninstall/types.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<object name="portal_types">
+ <object name="ftw.subsite.Subsite" remove="True" />
+</object>

--- a/ftw/subsite/profiles/uninstall/types/Plone_Site.xml
+++ b/ftw/subsite/profiles/uninstall/types/Plone_Site.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<object name="Plone Site">
+
+    <property name="allowed_content_types" purge="False">
+        <element value="ftw.subsite.Subsite" remove="True"/>
+    </property>
+
+</object>

--- a/ftw/subsite/profiles/uninstall/viewlets.xml
+++ b/ftw/subsite/profiles/uninstall/viewlets.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<object>
+
+  <order manager="plone.portalheader" skinname="*">
+    <viewlet remove="True" name="ftw.subsite.languageselector" />
+    <viewlet remove="True" name="ftw.subsite.banner" />
+  </order>
+
+</object>

--- a/ftw/subsite/profiles/uninstall_plone5/actions.xml
+++ b/ftw/subsite/profiles/uninstall_plone5/actions.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<object name="portal_actions" xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+
+  <object name="object" meta_type="CMF Action Category">
+    <object name="manage_portlets" remove="True"></object>
+  </object>
+
+  <object name="site_actions">
+    <object name="contact" i18n:domain="plone">
+      <!-- Reset to plone default instead of "@@contact-info" use "contact-info" -->
+      <property name="title" i18n:translate="">Contact</property>
+      <property name="description" i18n:translate=""></property>
+      <property name="url_expr">string:${globals_view/navigationRootUrl}/contact-info</property>
+      <property name="icon_expr"></property>
+      <property name="available_expr"></property>
+      <property name="permissions">
+        <element value="View"/>
+      </property>
+      <property name="visible">True</property>
+      <property name="modal" type="text">{}</property>
+    </object>
+  </object>
+
+</object>

--- a/ftw/subsite/profiles/uninstall_plone5/browserlayer.xml
+++ b/ftw/subsite/profiles/uninstall_plone5/browserlayer.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<layers>
+ <layer name="ftw_subsite"
+        remove="True"
+        interface="ftw.subsite.interfaces.IFtwSubsiteLayer" />
+</layers>

--- a/ftw/subsite/profiles/uninstall_plone5/registry.xml
+++ b/ftw/subsite/profiles/uninstall_plone5/registry.xml
@@ -5,17 +5,14 @@
              interface='Products.CMFPlone.interfaces.IResourceRegistry'
              remove="True"/>
 
-    <records prefix="plone.resources/ftw-subsite-resources"
-             interface='Products.CMFPlone.interfaces.IResourceRegistry'
+    <records prefix="plone.bundles/ftw-subsite-resources"
+             interface='Products.CMFPlone.interfaces.IBundleRegistry'
              remove="True"/>
 
-    <records
-        interface="Products.CMFPlone.interfaces.controlpanel.IImagingSchema"
-        prefix="plone">
-        <value key="allowed_sizes" purge="false">
-            <element remove="True">bannerimage 960:130</element>
-            <element remove="True">logo 215:56</element>
-        </value>
-    </records>
+    <record name="ftw.subsite.banner_root_only"
+            remove="True" />
+
+    <record name="ftw.subsite.bannerfoldername"
+            remove="True" />
 
 </registry>

--- a/ftw/subsite/profiles/uninstall_plone5/rolemap.xml
+++ b/ftw/subsite/profiles/uninstall_plone5/rolemap.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<rolemap>
+  <permissions>
+    <permission name="ftw.subsite: Add Subsite" acquire="True" />
+  </permissions>
+</rolemap>

--- a/ftw/subsite/profiles/uninstall_plone5/tinymce.xml
+++ b/ftw/subsite/profiles/uninstall_plone5/tinymce.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<object>
+  <resourcetypes>
+    <linkable purge="False">
+      <element value="ftw.subsite.Subsite" remove="True" />
+    </linkable>
+  </resourcetypes>
+</object>

--- a/ftw/subsite/profiles/uninstall_plone5/types.xml
+++ b/ftw/subsite/profiles/uninstall_plone5/types.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<object name="portal_types">
+ <object name="ftw.subsite.Subsite" remove="True" />
+</object>

--- a/ftw/subsite/profiles/uninstall_plone5/types/Plone_Site.xml
+++ b/ftw/subsite/profiles/uninstall_plone5/types/Plone_Site.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<object name="Plone Site">
+
+    <property name="allowed_content_types" purge="False">
+        <element value="ftw.subsite.Subsite" remove="True"/>
+    </property>
+
+</object>

--- a/ftw/subsite/profiles/uninstall_plone5/viewlets.xml
+++ b/ftw/subsite/profiles/uninstall_plone5/viewlets.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<object>
+
+    <order manager="plone.portalheader" skinname="*">
+        <viewlet remove="True" name="ftw.subsite.languageselector" />
+        <viewlet remove="True" name="ftw.subsite.banner" />
+    </order>
+
+</object>

--- a/ftw/subsite/tests/test_uninstall.py
+++ b/ftw/subsite/tests/test_uninstall.py
@@ -1,0 +1,9 @@
+from ftw.testing.genericsetup import GenericSetupUninstallMixin
+from ftw.testing.genericsetup import apply_generic_setup_layer
+from unittest import TestCase
+
+
+@apply_generic_setup_layer
+class TestGenericSetupUninstall(TestCase, GenericSetupUninstallMixin):
+    package = 'ftw.subsite'
+    skip_files = ('viewlets.xml', )


### PR DESCRIPTION
Resolves #116

Due to the weird behaviour of the viewlets.xml generic setup, we skip this file in the uninstall test and just ensure to remove all subsite viewlets.