### PR TITLE
Add plone5 condition for "Update bundle registration" upgrade step.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2.7.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- IResourceRegistry does not exist in plone4. Add condition to "Update bundle registration" upgrade step. [2e12]
 
 
 2.7.5 (2020-01-10)

--- a/ftw/subsite/upgrades/20191216175123_update_bundle_registration/upgrade.py
+++ b/ftw/subsite/upgrades/20191216175123_update_bundle_registration/upgrade.py
@@ -1,9 +1,13 @@
 from ftw.upgrade import UpgradeStep
+import pkg_resources
 
+
+IS_PLONE_5 = pkg_resources.get_distribution('Products.CMFPlone').version >= '5'
 
 class UpdateBundleRegistration(UpgradeStep):
     """Update bundle registration.
     """
 
     def __call__(self):
-        self.install_upgrade_profile()
+        if IS_PLONE_5:
+            self.install_upgrade_profile()


### PR DESCRIPTION
Upgrade step "Update bundle registration" fails on plone4 because "IResourceRegistry" isn't implemented in plone4.