### PR TITLE
Fix navroot missing attr

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2.7.9 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix contact form when not using Plone Site or Subsite as nav root [Nachtalb]
 
 
 2.7.8 (2020-10-02)

--- a/ftw/subsite/browser/contact.py
+++ b/ftw/subsite/browser/contact.py
@@ -93,8 +93,8 @@ class ContactForm(form.Form):
         default_from_email = portal.getProperty('email_from_address', '')
 
         if nav_root:
-            email_from_name = nav_root.from_name or default_from_name
-            email_from_email = nav_root.from_email or default_from_email
+            email_from_name = getattr(nav_root, 'from_name', default_from_name)
+            email_from_email = getattr(nav_root, 'from_email', default_from_email)
         else:
             email_from_name = default_from_name
             email_from_email = default_from_email


### PR DESCRIPTION
Not every kind of navroot has 'from_name' etc. set, thus we should have
a safe fallback.